### PR TITLE
Output dns

### DIFF
--- a/automate-training-5-ws.json
+++ b/automate-training-5-ws.json
@@ -1313,6 +1313,34 @@
       }
     }
   },
-  "Outputs":
-{"WindowsWorkstation1PubDNS":{"Description":"Public IP address of the Windows Workstation","Value":{"Fn::GetAtt":["WindowsWorkstation1","PublicIp"]}},"WindowsWorkstation2PubDNS":{"Description":"Public IP address of the Windows Workstation","Value":{"Fn::GetAtt":["WindowsWorkstation2","PublicIp"]}},"WindowsWorkstation3PubDNS":{"Description":"Public IP address of the Windows Workstation","Value":{"Fn::GetAtt":["WindowsWorkstation3","PublicIp"]}},"WindowsWorkstation4PubDNS":{"Description":"Public IP address of the Windows Workstation","Value":{"Fn::GetAtt":["WindowsWorkstation4","PublicIp"]}},"WindowsWorkstation5PubDNS":{"Description":"Public IP address of the Windows Workstation","Value":{"Fn::GetAtt":["WindowsWorkstation5","PublicIp"]}}}
+      "Outputs":{
+        "WindowsWorkstation1PubDNS":{
+          "Description":"Public IP address of the Windows Workstation",
+          "Value":{
+            "Fn::GetAtt":["WindowsWorkstation1","PublicIp"]
+          }
+        },
+        "WindowsWorkstation2PubDNS":{
+          "Description":"Public IP address of the Windows Workstation",
+          "Value":{
+            "Fn::GetAtt":["WindowsWorkstation2","PublicIp"]
+          }
+        },
+        "WindowsWorkstation3PubDNS":{
+          "Description":"Public IP address of the Windows Workstation",
+          "Value":{
+            "Fn::GetAtt":["WindowsWorkstation3","PublicIp"]
+          }
+        },
+        "WindowsWorkstation4PubDNS":{
+          "Description":"Public IP address of the Windows Workstation","Value":{
+          "Fn::GetAtt":["WindowsWorkstation4","PublicIp"]
+        }
+      },
+      "WindowsWorkstation5PubDNS":{
+        "Description":"Public IP address of the Windows Workstation","Value":{
+        "Fn::GetAtt":["WindowsWorkstation5","PublicIp"]
+      }
+    }
+  }
 }

--- a/automate-training-5-ws.json
+++ b/automate-training-5-ws.json
@@ -1323,7 +1323,7 @@
         "WindowsWorkstation1PubHostname":{
           "Description":"Public hostname of the Windows Workstation",
           "Value":{
-            "Fn::GetAtt":["WindowsWorkstation1","PublicHostname"]
+            "Fn::GetAtt":["WindowsWorkstation1","PublicDnsName"]
           }
         },
         "WindowsWorkstation2PubDNS":{

--- a/automate-training-5-ws.json
+++ b/automate-training-5-ws.json
@@ -1361,16 +1361,11 @@
         "Fn::GetAtt":["WindowsWorkstation4","PublicDnsName"]
       }
     },
-  "WindowsWorkstation5PubIP":{
+  "WindowsWorkstation5PubDNS":{
     "Description":"Public IP address of the Windows Workstation",
     "Value":{
-      "Fn::GetAtt":["WindowsWorkstation5","PublicIp"]
-      }
-    },
-    "WindowsWorkstation5PubDNS":{
-      "Description":"Public hostname of the Windows Workstation",
-      "Value":{
-        "Fn::GetAtt":["WindowsWorkstation5","PublicDnsName"]
+      "Fn::GetAtt":["WindowsWorkstation5","PublicIp"],
+      "Fn::GetAtt":["WindowsWorkstation5","PublicDnsName"]
       }
     }
   }

--- a/automate-training-5-ws.json
+++ b/automate-training-5-ws.json
@@ -1361,11 +1361,16 @@
         "Fn::GetAtt":["WindowsWorkstation4","PublicDnsName"]
       }
     },
-  "WindowsWorkstation5PubDNS":{
+  "WindowsWorkstation5PubIP":{
     "Description":"Public IP address of the Windows Workstation",
     "Value":{
-      "Fn::GetAtt":["WindowsWorkstation5","PublicIp"],
-      "Fn::GetAtt":["WindowsWorkstation5","PublicDnsName"]
+      "Fn::GetAtt":["WindowsWorkstation5","PublicIp"]
+      }
+    },
+    "WindowsWorkstation5PubDNS":{
+      "Description":"Public hostname of the Windows Workstation",
+      "Value":{
+        "Fn::GetAtt":["WindowsWorkstation5","PublicDnsName"]
       }
     }
   }

--- a/automate-training-5-ws.json
+++ b/automate-training-5-ws.json
@@ -1313,39 +1313,64 @@
       }
     }
   },
-      "Outputs":{
-        "WindowsWorkstation1PubDNS":{
-          "Description":"Public IP address of the Windows Workstation",
-          "Value":{
-            "Fn::GetAtt":["WindowsWorkstation1","PublicIp"]
-          }
-        },        
-        "WindowsWorkstation1PubHostname":{
-          "Description":"Public hostname of the Windows Workstation",
-          "Value":{
-            "Fn::GetAtt":["WindowsWorkstation1","PublicDnsName"]
-          }
-        },
-        "WindowsWorkstation2PubDNS":{
-          "Description":"Public IP address of the Windows Workstation",
-          "Value":{
-            "Fn::GetAtt":["WindowsWorkstation2","PublicIp"]
-          }
-        },
-        "WindowsWorkstation3PubDNS":{
-          "Description":"Public IP address of the Windows Workstation",
-          "Value":{
-            "Fn::GetAtt":["WindowsWorkstation3","PublicIp"]
-          }
-        },
-        "WindowsWorkstation4PubDNS":{
-          "Description":"Public IP address of the Windows Workstation","Value":{
-          "Fn::GetAtt":["WindowsWorkstation4","PublicIp"]
-        }
-      },
-      "WindowsWorkstation5PubDNS":{
-        "Description":"Public IP address of the Windows Workstation","Value":{
-        "Fn::GetAtt":["WindowsWorkstation5","PublicIp"]
+  "Outputs":{
+    "WindowsWorkstation1PubIP":{
+      "Description":"Public IP address of the Windows Workstation",
+      "Value":{
+        "Fn::GetAtt":["WindowsWorkstation1","PublicIp"]
+      }
+    },        
+    "WindowsWorkstation1PubDNS":{
+      "Description":"Public hostname of the Windows Workstation",
+      "Value":{
+        "Fn::GetAtt":["WindowsWorkstation1","PublicDnsName"]
+      }
+    },
+    "WindowsWorkstation2PubIP":{
+      "Description":"Public IP address of the Windows Workstation",
+      "Value":{
+        "Fn::GetAtt":["WindowsWorkstation2","PublicIp"]
+      }
+    },
+    "WindowsWorkstation2PubDNS":{
+      "Description":"Public hostname of the Windows Workstation",
+      "Value":{
+        "Fn::GetAtt":["WindowsWorkstation2","PublicDnsName"]
+      }
+    },
+    "WindowsWorkstation3PubIP":{
+      "Description":"Public IP address of the Windows Workstation",
+      "Value":{
+        "Fn::GetAtt":["WindowsWorkstation3","PublicIp"]
+      }
+    },
+    "WindowsWorkstation3PubDNS":{
+      "Description":"Public hostname of the Windows Workstation",
+      "Value":{
+        "Fn::GetAtt":["WindowsWorkstation3","PublicDnsName"]
+      }
+    },
+    "WindowsWorkstation4PubIP":{
+      "Description":"Public IP address of the Windows Workstation","Value":{
+      "Fn::GetAtt":["WindowsWorkstation4","PublicIp"]
+    }
+  },
+    "WindowsWorkstation4PubDNS":{
+      "Description":"Public hostname of the Windows Workstation",
+      "Value":{
+        "Fn::GetAtt":["WindowsWorkstation4","PublicDnsName"]
+      }
+    },
+  "WindowsWorkstation5PubIP":{
+    "Description":"Public IP address of the Windows Workstation",
+    "Value":{
+      "Fn::GetAtt":["WindowsWorkstation5","PublicIp"]
+      }
+    },
+    "WindowsWorkstation5PubDNS":{
+      "Description":"Public hostname of the Windows Workstation",
+      "Value":{
+        "Fn::GetAtt":["WindowsWorkstation5","PublicDnsName"]
       }
     }
   }

--- a/automate-training-5-ws.json
+++ b/automate-training-5-ws.json
@@ -1319,6 +1319,12 @@
           "Value":{
             "Fn::GetAtt":["WindowsWorkstation1","PublicIp"]
           }
+        },        
+        "WindowsWorkstation1PubHostname":{
+          "Description":"Public hostname of the Windows Workstation",
+          "Value":{
+            "Fn::GetAtt":["WindowsWorkstation1","PublicHostname"]
+          }
         },
         "WindowsWorkstation2PubDNS":{
           "Description":"Public IP address of the Windows Workstation",

--- a/automate-training-7-ws.json
+++ b/automate-training-7-ws.json
@@ -1423,6 +1423,65 @@
       }
     }
   },
-  "Outputs":
-{"WindowsWorkstation1PubDNS":{"Description":"Public IP address of the Windows Workstation","Value":{"Fn::GetAtt":["WindowsWorkstation1","PublicIp"]}},"WindowsWorkstation2PubDNS":{"Description":"Public IP address of the Windows Workstation","Value":{"Fn::GetAtt":["WindowsWorkstation2","PublicIp"]}},"WindowsWorkstation3PubDNS":{"Description":"Public IP address of the Windows Workstation","Value":{"Fn::GetAtt":["WindowsWorkstation3","PublicIp"]}},"WindowsWorkstation4PubDNS":{"Description":"Public IP address of the Windows Workstation","Value":{"Fn::GetAtt":["WindowsWorkstation4","PublicIp"]}},"WindowsWorkstation5PubDNS":{"Description":"Public IP address of the Windows Workstation","Value":{"Fn::GetAtt":["WindowsWorkstation5","PublicIp"]}},"WindowsWorkstation6PubDNS":{"Description":"Public IP address of the Windows Workstation","Value":{"Fn::GetAtt":["WindowsWorkstation6","PublicIp"]}},"WindowsWorkstation7PubDNS":{"Description":"Public IP address of the Windows Workstation","Value":{"Fn::GetAtt":["WindowsWorkstation7","PublicIp"]}}}
+  "Outputs":{
+    "WindowsWorkstation1PubIP":{
+      "Description":"Public IP address of the Windows Workstation",
+      "Value":{
+        "Fn::GetAtt":["WindowsWorkstation1","PublicIp"]
+      }
+    },        
+    "WindowsWorkstation1PubDNS":{
+      "Description":"Public hostname of the Windows Workstation",
+      "Value":{
+        "Fn::GetAtt":["WindowsWorkstation1","PublicDnsName"]
+      }
+    },
+    "WindowsWorkstation2PubIP":{
+      "Description":"Public IP address of the Windows Workstation",
+      "Value":{
+        "Fn::GetAtt":["WindowsWorkstation2","PublicIp"]
+      }
+    },
+    "WindowsWorkstation2PubDNS":{
+      "Description":"Public hostname of the Windows Workstation",
+      "Value":{
+        "Fn::GetAtt":["WindowsWorkstation2","PublicDnsName"]
+      }
+    },
+    "WindowsWorkstation3PubIP":{
+      "Description":"Public IP address of the Windows Workstation",
+      "Value":{
+        "Fn::GetAtt":["WindowsWorkstation3","PublicIp"]
+      }
+    },
+    "WindowsWorkstation3PubDNS":{
+      "Description":"Public hostname of the Windows Workstation",
+      "Value":{
+        "Fn::GetAtt":["WindowsWorkstation3","PublicDnsName"]
+      }
+    },
+    "WindowsWorkstation4PubIP":{
+      "Description":"Public IP address of the Windows Workstation","Value":{
+      "Fn::GetAtt":["WindowsWorkstation4","PublicIp"]
+    }
+  },
+    "WindowsWorkstation4PubDNS":{
+      "Description":"Public hostname of the Windows Workstation",
+      "Value":{
+        "Fn::GetAtt":["WindowsWorkstation4","PublicDnsName"]
+      }
+    },
+  "WindowsWorkstation5PubIP":{
+    "Description":"Public IP address of the Windows Workstation",
+    "Value":{
+      "Fn::GetAtt":["WindowsWorkstation5","PublicIp"]
+      }
+    },
+    "WindowsWorkstation5PubDNS":{
+      "Description":"Public hostname of the Windows Workstation",
+      "Value":{
+        "Fn::GetAtt":["WindowsWorkstation5","PublicDnsName"]
+      }
+    }
+  }
 }

--- a/automate-training-7-ws.json
+++ b/automate-training-7-ws.json
@@ -1482,6 +1482,30 @@
       "Value":{
         "Fn::GetAtt":["WindowsWorkstation5","PublicDnsName"]
       }
+    },
+    "WindowsWorkstation6PubIP":{
+    "Description":"Public IP address of the Windows Workstation",
+    "Value":{
+      "Fn::GetAtt":["WindowsWorkstation6","PublicIp"]
+      }
+    },
+    "WindowsWorkstation6PubDNS":{
+      "Description":"Public hostname of the Windows Workstation",
+      "Value":{
+        "Fn::GetAtt":["WindowsWorkstation6","PublicDnsName"]
+      }
+    },
+    "WindowsWorkstation7PubIP":{
+    "Description":"Public IP address of the Windows Workstation",
+    "Value":{
+      "Fn::GetAtt":["WindowsWorkstation7","PublicIp"]
+      }
+    },
+    "WindowsWorkstation7PubDNS":{
+      "Description":"Public hostname of the Windows Workstation",
+      "Value":{
+        "Fn::GetAtt":["WindowsWorkstation7","PublicDnsName"]
+      }
     }
   }
 }

--- a/automate-training-9-ws.json
+++ b/automate-training-9-ws.json
@@ -1533,6 +1533,65 @@
       }
     }
   },
-  "Outputs":
-{"WindowsWorkstation1PubDNS":{"Description":"Public IP address of the Windows Workstation","Value":{"Fn::GetAtt":["WindowsWorkstation1","PublicIp"]}},"WindowsWorkstation2PubDNS":{"Description":"Public IP address of the Windows Workstation","Value":{"Fn::GetAtt":["WindowsWorkstation2","PublicIp"]}},"WindowsWorkstation3PubDNS":{"Description":"Public IP address of the Windows Workstation","Value":{"Fn::GetAtt":["WindowsWorkstation3","PublicIp"]}},"WindowsWorkstation4PubDNS":{"Description":"Public IP address of the Windows Workstation","Value":{"Fn::GetAtt":["WindowsWorkstation4","PublicIp"]}},"WindowsWorkstation5PubDNS":{"Description":"Public IP address of the Windows Workstation","Value":{"Fn::GetAtt":["WindowsWorkstation5","PublicIp"]}},"WindowsWorkstation6PubDNS":{"Description":"Public IP address of the Windows Workstation","Value":{"Fn::GetAtt":["WindowsWorkstation6","PublicIp"]}},"WindowsWorkstation7PubDNS":{"Description":"Public IP address of the Windows Workstation","Value":{"Fn::GetAtt":["WindowsWorkstation7","PublicIp"]}},"WindowsWorkstation8PubDNS":{"Description":"Public IP address of the Windows Workstation","Value":{"Fn::GetAtt":["WindowsWorkstation8","PublicIp"]}},"WindowsWorkstation9PubDNS":{"Description":"Public IP address of the Windows Workstation","Value":{"Fn::GetAtt":["WindowsWorkstation9","PublicIp"]}}}
+  "Outputs":{
+    "WindowsWorkstation1PubIP":{
+      "Description":"Public IP address of the Windows Workstation",
+      "Value":{
+        "Fn::GetAtt":["WindowsWorkstation1","PublicIp"]
+      }
+    },        
+    "WindowsWorkstation1PubDNS":{
+      "Description":"Public hostname of the Windows Workstation",
+      "Value":{
+        "Fn::GetAtt":["WindowsWorkstation1","PublicDnsName"]
+      }
+    },
+    "WindowsWorkstation2PubIP":{
+      "Description":"Public IP address of the Windows Workstation",
+      "Value":{
+        "Fn::GetAtt":["WindowsWorkstation2","PublicIp"]
+      }
+    },
+    "WindowsWorkstation2PubDNS":{
+      "Description":"Public hostname of the Windows Workstation",
+      "Value":{
+        "Fn::GetAtt":["WindowsWorkstation2","PublicDnsName"]
+      }
+    },
+    "WindowsWorkstation3PubIP":{
+      "Description":"Public IP address of the Windows Workstation",
+      "Value":{
+        "Fn::GetAtt":["WindowsWorkstation3","PublicIp"]
+      }
+    },
+    "WindowsWorkstation3PubDNS":{
+      "Description":"Public hostname of the Windows Workstation",
+      "Value":{
+        "Fn::GetAtt":["WindowsWorkstation3","PublicDnsName"]
+      }
+    },
+    "WindowsWorkstation4PubIP":{
+      "Description":"Public IP address of the Windows Workstation","Value":{
+      "Fn::GetAtt":["WindowsWorkstation4","PublicIp"]
+    }
+  },
+    "WindowsWorkstation4PubDNS":{
+      "Description":"Public hostname of the Windows Workstation",
+      "Value":{
+        "Fn::GetAtt":["WindowsWorkstation4","PublicDnsName"]
+      }
+    },
+  "WindowsWorkstation5PubIP":{
+    "Description":"Public IP address of the Windows Workstation",
+    "Value":{
+      "Fn::GetAtt":["WindowsWorkstation5","PublicIp"]
+      }
+    },
+    "WindowsWorkstation5PubDNS":{
+      "Description":"Public hostname of the Windows Workstation",
+      "Value":{
+        "Fn::GetAtt":["WindowsWorkstation5","PublicDnsName"]
+      }
+    }
+  }
 }

--- a/automate-training-9-ws.json
+++ b/automate-training-9-ws.json
@@ -1592,6 +1592,54 @@
       "Value":{
         "Fn::GetAtt":["WindowsWorkstation5","PublicDnsName"]
       }
+    },
+        "WindowsWorkstation6PubIP":{
+    "Description":"Public IP address of the Windows Workstation",
+    "Value":{
+      "Fn::GetAtt":["WindowsWorkstation6","PublicIp"]
+      }
+    },
+    "WindowsWorkstation6PubDNS":{
+      "Description":"Public hostname of the Windows Workstation",
+      "Value":{
+        "Fn::GetAtt":["WindowsWorkstation6","PublicDnsName"]
+      }
+    },
+        "WindowsWorkstation7PubIP":{
+    "Description":"Public IP address of the Windows Workstation",
+    "Value":{
+      "Fn::GetAtt":["WindowsWorkstation7","PublicIp"]
+      }
+    },
+    "WindowsWorkstation7PubDNS":{
+      "Description":"Public hostname of the Windows Workstation",
+      "Value":{
+        "Fn::GetAtt":["WindowsWorkstation7","PublicDnsName"]
+      }
+    },
+    "WindowsWorkstation8PubIP":{
+    "Description":"Public IP address of the Windows Workstation",
+    "Value":{
+      "Fn::GetAtt":["WindowsWorkstation8","PublicIp"]
+      }
+    },
+    "WindowsWorkstation8PubDNS":{
+      "Description":"Public hostname of the Windows Workstation",
+      "Value":{
+        "Fn::GetAtt":["WindowsWorkstation8","PublicDnsName"]
+      }
+    },
+        "WindowsWorkstation9PubIP":{
+    "Description":"Public IP address of the Windows Workstation",
+    "Value":{
+      "Fn::GetAtt":["WindowsWorkstation9","PublicIp"]
+      }
+    },
+    "WindowsWorkstation9PubDNS":{
+      "Description":"Public hostname of the Windows Workstation",
+      "Value":{
+        "Fn::GetAtt":["WindowsWorkstation9","PublicDnsName"]
+      }
     }
   }
 }


### PR DESCRIPTION
Hey Steve, I created a fork of the automate templates that also outputs the public dns of the windows workstations to the "Outputs" section of the cloud formation console.

I think this is really useful for anyone teaching the Compliance course, since scanning windows nodes by public IP still doesn't seem to be working properly. Therefore it's really nice for the instructor to be able to access the dns quickly for distribution to students, instead of heading into the AWS console to dig it out. (normally I'd just tell students to run ohai on their workstations to access this info, but the ohai utility doesn't work properly on these windows nodes).

I've tested these and used the new automate-training-5-ws.json template in my last compliance course, with the expected behavior.

Let me know what you think, and if it's worth a merge. Thanks!